### PR TITLE
Fixed two bugs in ObjectsPlugin

### DIFF
--- a/tests/schemas/forward_reference_to_interface.graphql
+++ b/tests/schemas/forward_reference_to_interface.graphql
@@ -1,0 +1,7 @@
+type Foo {
+    forward: Ref
+}
+
+interface Ref {
+  id: ID
+}

--- a/tests/schemas/multiple_inhertiance.graphql
+++ b/tests/schemas/multiple_inhertiance.graphql
@@ -1,0 +1,18 @@
+interface A {
+  foo: String!
+}
+
+interface B implements A {
+  foo: String!
+  bar: String!
+ }
+
+type ThisInterfaceOrderWorksInPython implements B & A {
+  foo: String!
+  bar: String!
+}
+
+type ThisInterfaceOrderBreaksMROInPython implements A & B {
+  foo: String!
+  bar: String!
+}

--- a/tests/test_forward_reference_to_interface.py
+++ b/tests/test_forward_reference_to_interface.py
@@ -1,0 +1,34 @@
+import ast
+
+import pytest
+
+from tests.utils import build_relative_glob, generated_module_is_executable
+from turms.config import GeneratorConfig
+from turms.helpers import build_schema_from_glob
+from turms.plugins.objects import ObjectsPlugin
+from turms.run import generate_ast
+from turms.stylers.default import DefaultStyler
+
+
+@pytest.fixture()
+def forward_reference_to_interface_schema():
+    return build_schema_from_glob(
+        build_relative_glob("/schemas/forward_reference_to_interface.graphql")
+    )
+
+
+def test_generation(forward_reference_to_interface_schema):
+    config = GeneratorConfig()
+
+    generated_ast = generate_ast(
+        config,
+        forward_reference_to_interface_schema,
+        stylers=[DefaultStyler()],
+        plugins=[
+            ObjectsPlugin(),
+        ],
+    )
+
+    md = ast.Module(body=generated_ast, type_ignores=[])
+    generated = ast.unparse(ast.fix_missing_locations(md))
+    assert generated_module_is_executable(generated)

--- a/tests/test_mulitple_inheritance.py
+++ b/tests/test_mulitple_inheritance.py
@@ -1,0 +1,34 @@
+import ast
+
+import pytest
+
+from tests.utils import build_relative_glob, generated_module_is_executable
+from turms.config import GeneratorConfig
+from turms.helpers import build_schema_from_glob
+from turms.plugins.objects import ObjectsPlugin
+from turms.run import generate_ast
+from turms.stylers.default import DefaultStyler
+
+
+@pytest.fixture()
+def multiple_inheritance_schema():
+    return build_schema_from_glob(
+        build_relative_glob("/schemas/multiple_inhertiance.graphql")
+    )
+
+
+def test_generation(multiple_inheritance_schema):
+    config = GeneratorConfig()
+
+    generated_ast = generate_ast(
+        config,
+        multiple_inheritance_schema,
+        stylers=[DefaultStyler()],
+        plugins=[
+            ObjectsPlugin(),
+        ],
+    )
+
+    md = ast.Module(body=generated_ast, type_ignores=[])
+    generated = ast.unparse(ast.fix_missing_locations(md))
+    assert generated_module_is_executable(generated)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,3 +5,19 @@ DIR_NAME = os.path.dirname(os.path.realpath(__file__))
 
 def build_relative_glob(path):
     return DIR_NAME + path
+
+
+def generated_module_is_executable(module: str) -> bool:
+    exec_locals = {}
+    exec_globals = {}
+
+    imports = [line for line in module.split("\n") if line.startswith("from")]
+    for import_ in imports:
+        exec(import_, exec_globals, exec_locals)
+    exec_globals.update(exec_locals)
+
+    try:
+        exec(module, exec_globals)
+    except:
+        return False
+    return True

--- a/turms/plugins/objects.py
+++ b/turms/plugins/objects.py
@@ -7,19 +7,22 @@ from graphql import (
     GraphQLScalarType,
     GraphQLType,
     GraphQLUnionType,
+    is_wrapping_type,
 )
 from turms.plugins.base import Plugin, PluginConfig
 import ast
 from typing import List
 from turms.config import GeneratorConfig
 from graphql.utilities.build_client_schema import GraphQLSchema
-from turms.plugins.base import Plugin
 from pydantic import Field
 from graphql.type.definition import (
     GraphQLEnumType,
 )
 from turms.registry import ClassRegistry
-from turms.utils import get_additional_bases_for_type
+from turms.utils import (
+    get_additional_bases_for_type,
+    interface_is_extended_by_other_interfaces,
+)
 
 
 class ObjectsPluginConfig(PluginConfig):
@@ -225,12 +228,15 @@ def generate_types(
 
         for interface in object_type.interfaces:
             interface_map.setdefault(interface.name, []).append(name)
-            additional_bases.append(
-                ast.Name(
-                    id=f"{registry.generate_interface_classname(interface.name)}Base",
-                    ctx=ast.Load(),
+
+            other_interfaces = set(object_type.interfaces) - {interface}
+            if not interface_is_extended_by_other_interfaces(interface, other_interfaces):
+                additional_bases.append(
+                    ast.Name(
+                        id=f"{registry.generate_interface_classname(interface.name)}Base",
+                        ctx=ast.Load(),
+                    )
                 )
-            )
 
         fields = (
             [ast.Expr(value=ast.Constant(value=object_type.description))]
@@ -239,24 +245,17 @@ def generate_types(
         )
 
         for value_key, value in object_type.fields.items():
+            type_ = value.type
+            while is_wrapping_type(type_):
+                type_ = type_.of_type
 
-            if isinstance(value.type, GraphQLNonNull):
-                if isinstance(value.type.of_type, GraphQLObjectType):
-                    self_referential.add(
-                        registry.generate_inputtype_classname(value.type.of_type.name)
-                    )
-                if isinstance(value.type.of_type, GraphQLInterfaceType):
-                    self_referential.add(
-                        registry.generate_interface_classname(value.type.of_type.name)
-                    )
-
-            if isinstance(value.type, GraphQLObjectType):
+            if isinstance(type_, GraphQLObjectType):
                 self_referential.add(
-                    registry.generate_inputtype_classname(value.type.name)
+                    registry.generate_objecttype_classname(type_.name)
                 )
-            if isinstance(value.type, GraphQLInterfaceType):
+            elif isinstance(type_, GraphQLInterfaceType):
                 self_referential.add(
-                    registry.generate_interface_classname(value.type.name)
+                    f"{registry.generate_interface_classname(type_.name)}Base"
                 )
 
             field_name = registry.generate_node_name(value_key)

--- a/turms/utils.py
+++ b/turms/utils.py
@@ -1,6 +1,6 @@
 import glob
 import re
-from typing import Dict, List
+from typing import Dict, List, Set
 from turms.config import GeneratorConfig
 from graphql.utilities.build_client_schema import GraphQLSchema
 from graphql.language.ast import DocumentNode, FieldNode
@@ -9,6 +9,7 @@ from graphql import (
     parse,
     validate,
     build_client_schema,
+    GraphQLInterfaceType,
 )
 import ast
 from turms.registry import ClassRegistry
@@ -175,3 +176,13 @@ def get_interface_bases(config: GeneratorConfig, registry: ClassRegistry):
             ast.Name(id=base.split(".")[-1], ctx=ast.Load())
             for base in config.object_bases
         ]
+
+
+def interface_is_extended_by_other_interfaces(interface: GraphQLInterfaceType,
+                                              other_interfaces: Set[GraphQLInterfaceType]) -> bool:
+    interfaces_implemented_by_other_interfaces = {
+        nested_interface
+        for other_interface in other_interfaces
+        for nested_interface in other_interface.interfaces
+    }
+    return interface in interfaces_implemented_by_other_interfaces


### PR DESCRIPTION
fixes #24 
* Multiple inheritance could result in an invalid MRO of the generated pydantic types.

* If an interface was used as a forward reference, the wrong variable was used to call `update_forward_refs()`.

may Fix #23 
* Extended unraveling of wrapped type
  https://github.com/jhnnsrs/turms/compare/master...j-riebe:master#diff-ba9518bcc774b42fd3b54830810de2aa74832a6584657a094513b61c1d3517ceL243-R258

* Added test function that checks the generated module for runtime errors
https://github.com/jhnnsrs/turms/compare/master...j-riebe:master#diff-9e08e8c7769db7b58089fd7659d75ca96df40bb7b5d50299d3a30abd54da9ad6R10-R23
