### PR TITLE
added ability to parse for document documentation (

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Run Poetry Install
         run: poetry install
       - name: Run Tests
-        run: poetry run pytest --cov turms --cov-report=xml .
+        run: poetry run pytest --cov --cov-report=xml .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Run Poetry Install
         run: poetry install
       - name: Run Tests
-        run: poetry run pytest --cov --cov-report=xml .
+        run: poetry run pytest --cov turms --cov-report=xml .
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turms"
-version = "0.2.4"
+version = "0.2.5-alpha.0"
 description = "graphql-codegen powered by pydantic"
 authors = ["jhnnsrs <jhnnsrs@gmail.com>"]
 license = "CC BY-NC 3.0"

--- a/tests/documents/documentation/test.graphql
+++ b/tests/documents/documentation/test.graphql
@@ -1,0 +1,18 @@
+mutation createBeast($nested: [[String!]!], $nonOptionalParameter: String!) {
+  # Testing the documentatoin ability
+  createBeast(nested: $nested, nonOptionalParameter: $nonOptionalParameter) {
+    binomial # field docu
+  }
+}
+
+mutation createBeastss($nested: [[String!]!], $nonOptionalParameter: String!) {
+  createBeast(nested: $nested, nonOptionalParameter: $nonOptionalParameter) {
+    binomial
+  }
+}
+
+mutation fsdfsd($nested: [[String!]!], $nonOptionalParameter: String!) {
+  createBeast(nested: $nested, nonOptionalParameter: $nonOptionalParameter) {
+    binomial
+  }
+}

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,93 @@
+import ast
+
+import pytest
+from .utils import build_relative_glob, unit_test_with
+from turms.config import GeneratorConfig
+from turms.run import generate_ast
+from turms.plugins.enums import EnumsPlugin
+from turms.plugins.inputs import InputsPlugin
+from turms.plugins.fragments import FragmentsPlugin
+from turms.plugins.operations import OperationsPlugin
+from turms.plugins.funcs import (
+    FunctionDefinition,
+    FuncsPlugin,
+    FuncsPluginConfig,
+)
+from turms.stylers.snake_case import SnakeCaseStyler
+from turms.stylers.capitalize import CapitalizeStyler
+from turms.helpers import build_schema_from_glob
+
+
+@pytest.fixture()
+def nested_input_schema():
+    return build_schema_from_glob(build_relative_glob("/schemas/nested_inputs.graphql"))
+
+
+def test_documentatoin(nested_input_schema):
+    config = GeneratorConfig(
+        documents=build_relative_glob("/documents/documentation/*.graphql"),
+    )
+    generated_ast = generate_ast(
+        config,
+        nested_input_schema,
+        stylers=[CapitalizeStyler(), SnakeCaseStyler()],
+        plugins=[
+            EnumsPlugin(),
+            InputsPlugin(),
+            FragmentsPlugin(),
+            OperationsPlugin(),
+            FuncsPlugin(
+                config=FuncsPluginConfig(
+                    definitions=[
+                        FunctionDefinition(
+                            type="mutation",
+                            use="turms.mocks.aquery",
+                            is_async=False,
+                        ),
+                        FunctionDefinition(
+                            type="mutation",
+                            use="turms.mocks.aquery",
+                            is_async=True,
+                        ),
+                    ]
+                ),
+            ),
+        ],
+    )
+
+    # unit_test_with(generated_ast, "")
+
+
+def test_default_input_funcs(nested_input_schema):
+    config = GeneratorConfig(
+        documents=build_relative_glob("/documents/inputs_default/*.graphql"),
+    )
+    generated_ast = generate_ast(
+        config,
+        nested_input_schema,
+        stylers=[CapitalizeStyler(), SnakeCaseStyler()],
+        plugins=[
+            EnumsPlugin(),
+            InputsPlugin(),
+            FragmentsPlugin(),
+            OperationsPlugin(),
+            FuncsPlugin(
+                config=FuncsPluginConfig(
+                    definitions=[
+                        FunctionDefinition(
+                            type="mutation",
+                            use="tests.mocks.aquery",
+                            is_async=False,
+                        ),
+                        FunctionDefinition(
+                            type="mutation",
+                            use="tests.mocks.aquery",
+                            is_async=True,
+                        ),
+                    ]
+                ),
+            ),
+        ],
+    )
+
+    unit_test_with(generated_ast, "")

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -55,7 +55,7 @@ def test_documentatoin(nested_input_schema):
         ],
     )
 
-    # unit_test_with(generated_ast, "")
+    unit_test_with(generated_ast, "")
 
 
 def test_default_input_funcs(nested_input_schema):

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -41,12 +41,12 @@ def test_documentatoin(nested_input_schema):
                     definitions=[
                         FunctionDefinition(
                             type="mutation",
-                            use="turms.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="turms.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                     ]
@@ -76,12 +76,12 @@ def test_default_input_funcs(nested_input_schema):
                     definitions=[
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                     ]

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -55,32 +55,32 @@ def test_arkitekt_schema(arkitekt_schema):
                     definitions=[
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.subscribe",
+                            use="mocks.subscribe",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.asubscribe",
+                            use="mocks.asubscribe",
                             is_async=True,
                         ),
                     ]
@@ -121,32 +121,32 @@ def test_beasts_schema(beasts_schema):
                     definitions=[
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.subscribe",
+                            use="mocks.subscribe",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.asubscribe",
+                            use="mocks.asubscribe",
                             is_async=True,
                         ),
                     ]
@@ -169,7 +169,7 @@ def test_extra_args(beasts_schema):
     extra_args = [
         Arg(
             key="client",
-            type="tests.mocks.ExtraArg",
+            type="mocks.ExtraArg",
             description="An Extra Arg",
         )
     ]
@@ -197,42 +197,42 @@ def test_extra_args(beasts_schema):
                     definitions=[
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=False,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,
                         ),
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=True,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.subscribe",
+                            use="mocks.subscribe",
                             is_async=False,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.asubscribe",
+                            use="mocks.asubscribe",
                             is_async=True,
                             extra_args=extra_args,
                             extra_kwargs=extra_kwargs,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,4 +24,4 @@ def test_utf8_bom():
     """
     Tests that the files with UTF8-BOM are readable.
     """
-    build_schema_from_glob(os.path.join(DIR_NAME, "/schemas/helloworld_bom.graphql")
+    build_schema_from_glob(os.path.join(DIR_NAME, "schemas/helloworld_bom.graphql"))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+from .utils import DIR_NAME
 
 from turms.helpers import import_string, build_schema_from_glob
 
@@ -15,4 +17,4 @@ def test_schema_from_introspection_json():
     """
     Tests that the result of an introspection query can be read from a file.
     """
-    build_schema_from_glob("tests/introspection/spacex.json")
+    build_schema_from_glob(os.path.join(DIR_NAME, "introspection/spacex.json"))

--- a/tests/test_multi_interface.py
+++ b/tests/test_multi_interface.py
@@ -41,32 +41,32 @@ def test_multi_interface_funcs(multi_interface_schema):
                     definitions=[
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.subscribe",
+                            use="mocks.subscribe",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.asubscribe",
+                            use="mocks.asubscribe",
                             is_async=True,
                         ),
                     ]

--- a/tests/test_nested_input.py
+++ b/tests/test_nested_input.py
@@ -41,17 +41,17 @@ def test_nested_input_funcs(nested_input_schema):
                     definitions=[
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                     ]
                 ),
-            )
+            ),
         ],
     )
 
@@ -76,17 +76,17 @@ def test_default_input_funcs(nested_input_schema):
                     definitions=[
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                     ]
                 ),
-            )
+            ),
         ],
     )
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -40,10 +40,10 @@ def test_extra_arguments(arkitekt_schema):
             FragmentsPlugin(),
             OperationsPlugin(
                 config=OperationsPluginConfig(
-                    subscription_bases=["tests.mocks.ExtraOnOperations"],
-                    mutation_bases=["tests.mocks.ExtraOnOperations"],
-                    query_bases=["tests.mocks.ExtraOnOperations"],
-                    arguments_bases=["tests.mocks.ExtraArguments"],
+                    subscription_bases=["mocks.ExtraOnOperations"],
+                    mutation_bases=["mocks.ExtraOnOperations"],
+                    query_bases=["mocks.ExtraOnOperations"],
+                    arguments_bases=["mocks.ExtraArguments"],
                 )
             ),
         ],

--- a/tests/test_plugin_order.py
+++ b/tests/test_plugin_order.py
@@ -44,32 +44,32 @@ def test_different_plugin_order(arkitekt_schema):
                     definitions=[
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="query",
-                            use="tests.mocks.query",
+                            use="mocks.query",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="mutation",
-                            use="tests.mocks.aquery",
+                            use="mocks.aquery",
                             is_async=True,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.subscribe",
+                            use="mocks.subscribe",
                             is_async=False,
                         ),
                         FunctionDefinition(
                             type="subscription",
-                            use="tests.mocks.asubscribe",
+                            use="mocks.asubscribe",
                             is_async=True,
                         ),
                     ]

--- a/turms/config.py
+++ b/turms/config.py
@@ -1,6 +1,6 @@
 import builtins
 from pydantic import AnyHttpUrl, BaseModel, BaseSettings, Field, validator
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from turms.helpers import import_string
 
 
@@ -39,6 +39,7 @@ class GeneratorConfig(BaseSettings):
     scalar_definitions: Dict[str, PythonScalar] = {}
     freeze: bool = False
     additional_bases = {}
+    additional_config: Dict[str, Dict[str, Any]] = {}
     force_plugin_order: bool = True
 
     parsers: List[ConfigProxy] = []

--- a/turms/helpers.py
+++ b/turms/helpers.py
@@ -1,6 +1,6 @@
 import json
 from importlib import import_module
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 from urllib import request
 import glob
 import graphql

--- a/turms/helpers.py
+++ b/turms/helpers.py
@@ -1,6 +1,6 @@
 import json
 from importlib import import_module
-from typing import Optional
+from typing import Any, Dict, Optional
 from urllib import request
 import glob
 import graphql
@@ -39,7 +39,9 @@ def import_string(dotted_path):
         ) from err
 
 
-def introspect_url(schema_url: str, bearer_token: Optional[str] = None) -> {}:
+def introspect_url(
+    schema_url: str, bearer_token: Optional[str] = None
+) -> Dict[str, Any]:
     """Introspect a GraphQL schema using introspection query
 
     Args:

--- a/turms/mocks.py
+++ b/turms/mocks.py
@@ -1,0 +1,35 @@
+from typing import Optional, Type, TypeVar
+
+from pydantic import BaseModel
+
+T = TypeVar("T")
+
+
+def query(model: Type[T], variables) -> T:
+    return model(variables)  # pragma: nocover
+
+
+async def aquery(model: Type[T], variables) -> T:
+    return model(variables)  # pragma: nocover
+
+
+def subscribe(model: Type[T], variables) -> T:
+    yield model(variables)  # pragma: nocover
+    yield model(variables)  # pragma: nocover
+
+
+async def asubscribe(model: Type[T], variables) -> T:
+    yield model(variables)  # pragma: nocover
+    yield model(variables)  # pragma: nocover
+
+
+class ExtraArguments(BaseModel):
+    extra: Optional[str]
+
+
+class ExtraOnOperations(BaseModel):
+    extra: Optional[str]
+
+
+class ExtraArg(BaseModel):
+    extra: Optional[str]

--- a/turms/plugins/funcs.py
+++ b/turms/plugins/funcs.py
@@ -330,10 +330,16 @@ def get_return_type_annotation(
                     ).id,
                 )
 
+        field_name = (
+            collapsable_field.name.value
+            if not collapsable_field.alias
+            else collapsable_field.alias.value
+        )
+
         return recurse_outputtype_annotation(
             field_definition.type,
             registry,
-            overwrite_final=f"{o_name}{collapsable_field.name.value.capitalize()}",
+            overwrite_final=f"{o_name}{field_name.capitalize()}",
         )
 
     return ast.Name(

--- a/turms/plugins/inputs.py
+++ b/turms/plugins/inputs.py
@@ -16,7 +16,7 @@ from graphql.type.definition import (
     GraphQLEnumType,
 )
 from turms.registry import ClassRegistry
-from turms.utils import get_additional_bases_for_type
+from turms.utils import generate_config_class, get_additional_bases_for_type
 
 
 class InputsPluginConfig(PluginConfig):
@@ -205,7 +205,7 @@ def generate_inputs(
                 + additional_bases,
                 decorator_list=[],
                 keywords=[],
-                body=fields,
+                body=fields + generate_config_class(config, typename=key),
             )
         )
 

--- a/turms/plugins/objects.py
+++ b/turms/plugins/objects.py
@@ -329,7 +329,7 @@ def generate_types(
                 ],
                 decorator_list=[],
                 keywords=[],
-                body=fields + generate_config_class(key, config),
+                body=fields + generate_config_class(config, key),
             )
         )
 

--- a/turms/plugins/objects.py
+++ b/turms/plugins/objects.py
@@ -22,6 +22,7 @@ from graphql.type.definition import (
 )
 from turms.registry import ClassRegistry
 from turms.utils import (
+    generate_config_class,
     get_additional_bases_for_type,
     interface_is_extended_by_other_interfaces,
 )
@@ -328,7 +329,7 @@ def generate_types(
                 ],
                 decorator_list=[],
                 keywords=[],
-                body=fields,
+                body=fields + generate_config_class(key, config),
             )
         )
 

--- a/turms/plugins/operations.py
+++ b/turms/plugins/operations.py
@@ -21,6 +21,7 @@ from turms.registry import ClassRegistry
 from turms.utils import (
     NoDocumentsFoundError,
     generate_config_class,
+    inspect_operation_for_documentation,
     parse_documents,
     recurse_type_annotation,
     replace_iteratively,
@@ -41,6 +42,7 @@ class OperationsPluginConfig(PluginConfig):
     subscription_bases: List[str] = None
     operations_glob: Optional[str]
     create_arguments: bool = True
+    extract_documentation: bool = True
 
     class Config:
         env_prefix = "TURMS_PLUGINS_OPERATIONS_"
@@ -166,6 +168,18 @@ def generate_operation(
 
     x = get_operation_root_type(client_schema, o)
     class_body_fields = []
+
+    operation_documentation = (
+        inspect_operation_for_documentation(o)
+        if plugin_config.extract_documentation
+        else None
+    )
+    if operation_documentation:
+        class_body_fields.append(
+            ast.Expr(
+                value=ast.Str(s=operation_documentation),
+            )
+        )
 
     for field_node in o.selection_set.selections:
         field_node: FieldNode = field_node

--- a/turms/recurse.py
+++ b/turms/recurse.py
@@ -1,3 +1,4 @@
+from xml.dom.expatbuilder import parseFragment
 from turms.config import GeneratorConfig
 from graphql.utilities.build_client_schema import GraphQLSchema
 from graphql.language.ast import (
@@ -254,22 +255,22 @@ def recurse_annotation(
 
         # Single Item collapse
         if len(node.selection_set.selections) == 1:
-            subnode = node.selection_set.selections[0]
-            if isinstance(subnode, FragmentSpreadNode):
+            sub_node = node.selection_set.selections[0]
+            if isinstance(sub_node, FragmentSpreadNode):
                 if is_optional:
                     registry.register_import("typing.Optional")
                     return ast.Subscript(
                         value=ast.Name("Optional", ctx=ast.Load()),
                         slice=registry.reference_fragment(
-                            subnode.name.value, object_class_name
-                        ),
+                            sub_node.name.value, parent
+                        ),  # needs to be parent not object as reference will be to parent
                         ctx=ast.Load(),
                     )
 
                 else:
                     return registry.reference_fragment(
-                        subnode.name.value, object_class_name
-                    )
+                        sub_node.name.value, parent
+                    )  # needs to be parent not object as reference will be to parent
 
         for sub_node in node.selection_set.selections:
 


### PR DESCRIPTION
enables

```graphql

query get_name($id: ID){
# this is the documentation
# it also enables multiline
nana(id: $id) {
   name
  }
}

```

to be parsed to

````python

class GetNameQuery(BaseModel):
    """this is the documentation
    it also enables multiline"""   
   nana: GetNameQueryNana

   class Arguments(BaseModel):
     id: ID

