### PR TITLE
Handle UTF-8 BOM schema files.

### DIFF
--- a/tests/schemas/helloworld_bom.graphql
+++ b/tests/schemas/helloworld_bom.graphql
@@ -1,0 +1,24 @@
+﻿type Query {
+  hello(
+    orderBy: HelloWorldOrder! = ASC
+    filter: HelloWorldFilter
+    first: Int
+    last: Int
+    before: String
+    after: String
+  ): [World!]!
+}
+
+enum HelloWorldOrder {
+  ASC
+  "A beautiful thing"
+  DESC
+}
+
+input HelloWorldFilter {
+  searchMassimo: String!
+}
+
+type World {
+  message: String!
+}

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,3 +16,10 @@ def test_schema_from_introspection_json():
     Tests that the result of an introspection query can be read from a file.
     """
     build_schema_from_glob("tests/introspection/spacex.json")
+
+
+def test_utf8_bom():
+    """
+    Tests that the files with UTF8-BOM are readable.
+    """
+    build_schema_from_glob("tests/schemas/helloworld_bom.graphql")

--- a/turms/helpers.py
+++ b/turms/helpers.py
@@ -96,12 +96,13 @@ def build_schema_from_glob(glob_string: str):
     dsl_string = ""
     introspection_string = ""
     for file in schema_glob:
-        with open(file, "r") as f:
+        with open(file, "rb") as f:
+            decoded_file = f.read().decode("utf-8-sig")
             if file.endswith(".graphql"):
-                dsl_string += f.read()
+                dsl_string += decoded_file
             elif file.endswith(".json"):
                 # not really necessary as json files are generally not splitable
-                introspection_string += f.read()
+                introspection_string += decoded_file
 
     if not dsl_string and not introspection_string:
         raise GenerationError(f"No schema files found in {glob_string}")


### PR DESCRIPTION
Found this issue when trying to read a schema file with a UTF-8 byte order mark.