### PR TITLE
Consistent forward references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ black = "^22.1.0"
 pylint = "^2.12.2"
 autoflake = "^1.4"
 
-
 [tool.poetry.extras]
 watch = ["watchdog"]
 black = ["black"]

--- a/tests/schemas/multiple_forward_references.graphql
+++ b/tests/schemas/multiple_forward_references.graphql
@@ -1,0 +1,21 @@
+type ParentForwardReference {
+    forward_one: ForwardReferenceOne
+    forward_two: ForwardReferenceTwo
+    forward_three: ForwardReferenceThree
+}
+
+type ForwardReferenceOne {
+    forward: Ref
+}
+
+type ForwardReferenceTwo {
+    forward: Ref
+}
+
+type ForwardReferenceThree {
+    forward: Ref
+}
+
+type Ref {
+  id: ID
+}

--- a/tests/test_multiple_forward_references.py
+++ b/tests/test_multiple_forward_references.py
@@ -1,0 +1,50 @@
+import ast
+
+import pytest
+
+from .utils import (
+    build_relative_glob,
+    unit_test_with,
+)
+from turms.config import GeneratorConfig
+from turms.helpers import build_schema_from_glob
+from turms.plugins.objects import ObjectsPlugin
+from turms.run import generate_ast
+from turms.stylers.default import DefaultStyler
+
+
+@pytest.fixture()
+def multiple_forward_references_schema():
+    return build_schema_from_glob(
+        build_relative_glob("/schemas/multiple_forward_references.graphql")
+    )
+
+
+def test_generation(multiple_forward_references_schema):
+    config = GeneratorConfig()
+
+    generated_ast = generate_ast(
+        config,
+        multiple_forward_references_schema,
+        stylers=[DefaultStyler()],
+        plugins=[
+            ObjectsPlugin(),
+        ],
+    )
+
+    forward_refs = []
+    for node in generated_ast:
+        if not isinstance(node, ast.Expr):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        if not isinstance(node.value.func, ast.Attribute):
+            continue
+        if node.value.func.attr == "update_forward_refs" and isinstance(
+            node.value.func.value, ast.Name
+        ):
+            forward_refs.append(node.value.func.value.id)
+
+    assert forward_refs == sorted(forward_refs)
+
+    unit_test_with(generated_ast, "")

--- a/turms/registry.py
+++ b/turms/registry.py
@@ -398,7 +398,7 @@ class ClassRegistry(object):
     def generate_forward_refs(self):
         tree = []
 
-        for reference in self.forward_references:
+        for reference in sorted(self.forward_references):
             tree.append(
                 ast.Expr(
                     value=ast.Call(

--- a/turms/registry.py
+++ b/turms/registry.py
@@ -182,11 +182,29 @@ class ClassRegistry(object):
     def reference_object(
         self, typename: str, parent: str, allow_forward=True
     ) -> ast.AST:
-        classname = self.style_objecttype_class(typename)
-        if typename not in self.object_class_map or parent == classname:
+        return self._reference_generic(
+            typename,
+            parent,
+            self.style_objecttype_class,
+            self.object_class_map,
+            "Object",
+            allow_forward,
+        )
+
+    def _reference_generic(
+        self,
+        typename: str,
+        parent: str,
+        styler,
+        class_map: {},
+        error_class: str,
+        allow_forward=True,
+    ) -> ast.AST:
+        classname = styler(typename)
+        if typename not in class_map or parent == classname:
             if not allow_forward:
                 raise RegistryError(
-                    f"Object type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"
+                    f"""{error_class} type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"""
                 )
             self.forward_references.add(parent)
             return ast.Constant(value=classname, ctx=ast.Load())
@@ -241,15 +259,14 @@ class ClassRegistry(object):
     def reference_fragment(
         self, typename: str, parent: str, allow_forward=True
     ) -> ast.AST:
-        classname = self.style_fragment_class(typename)
-        if typename not in self.fragment_class_map or parent == classname:
-            if not allow_forward:
-                raise RegistryError(
-                    f"Object type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"
-                )
-            self.forward_references.add(parent)
-            return ast.Constant(value=classname, ctx=ast.Load())
-        return ast.Name(id=classname, ctx=ast.Load())
+        return self._reference_generic(
+            typename,
+            parent,
+            self.style_fragment_class,
+            self.fragment_class_map,
+            "Fragment",
+            allow_forward,
+        )
 
     def inherit_fragment(self, typename: str, allow_forward=True) -> ast.AST:
         if typename not in self.fragment_class_map:
@@ -294,15 +311,14 @@ class ClassRegistry(object):
     def reference_query(
         self, typename: str, parent: str, allow_forward=True
     ) -> ast.AST:
-        classname = self.style_query_class(typename)
-        if typename not in self.query_class_map or parent == classname:
-            if not allow_forward:
-                raise RegistryError(
-                    f"Query type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"
-                )
-            self.forward_references.add(parent)
-            return ast.Constant(value=classname, ctx=ast.Load())
-        return ast.Name(id=classname, ctx=ast.Load())
+        return self._reference_generic(
+            typename,
+            parent,
+            self.style_query_class,
+            self.query_class_map,
+            "Query",
+            allow_forward,
+        )
 
     def style_mutation_class(self, typename: str):
         for styler in self.stylers:
@@ -322,15 +338,14 @@ class ClassRegistry(object):
     def reference_mutation(
         self, typename: str, parent: str, allow_forward=True
     ) -> ast.AST:
-        classname = self.style_mutation_class(typename)
-        if typename not in self.mutation_class_map or parent == classname:
-            if not allow_forward:
-                raise RegistryError(
-                    f"Query type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"
-                )
-            self.forward_references.add(parent)
-            return ast.Constant(value=classname, ctx=ast.Load())
-        return ast.Name(id=classname, ctx=ast.Load())
+        return self._reference_generic(
+            typename,
+            parent,
+            self.style_mutation_class,
+            self.mutation_class_map,
+            "Mutation",
+            allow_forward,
+        )
 
     def style_subscription_class(self, typename: str):
         for styler in self.stylers:
@@ -350,15 +365,14 @@ class ClassRegistry(object):
     def reference_subscription(
         self, typename: str, parent: str, allow_forward=True
     ) -> ast.AST:
-        classname = self.style_subscription_class(typename)
-        if typename not in self.subscription_class_map or parent == classname:
-            if not allow_forward:
-                raise RegistryError(
-                    f"Query type {typename} is not yet defined but referenced by {parent}. And we dont allow forward references"
-                )
-            self.forward_references.add(parent)
-            return ast.Constant(value=classname, ctx=ast.Load())
-        return ast.Name(id=classname, ctx=ast.Load())
+        return self._reference_generic(
+            typename,
+            parent,
+            self.style_subscription_class,
+            self.subscription_class_map,
+            "Subscription",
+            allow_forward,
+        )
 
     def register_import(self, name):
         if name in ("bool", "str", "int", "float", "dict", "list", "tuple"):


### PR DESCRIPTION
Found that forward references would reorder themselves every time the file was generated. It's difficult to test as the ordering of a set is related to the random number seed.

I forced these to be sorted alphabetically which keeps the output file more consistent.

I also refactored some repeated code in registry.py but can remove that if you prefer.