### PR TITLE
Skip unreferenced as default

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,6 @@
   },
 
   "files.exclude": {
-    "**/venv": true,
     "**/__pycache__": true,
     "**/.pytest_cache": true
   },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,12 +7,12 @@
     {
       "label": "Patch",
       "type": "shell",
-      "command": "source venv/bin/activate && poetry version patch && poetry build "
+      "command": " poetry version patch && poetry build "
     },
     {
       "label": "Publish",
       "type": "shell",
-      "command": "source venv/bin/activate && poetry publish"
+      "command": " poetry publish"
     },
     {
       "type": "shell",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "turms"
-version = "0.4.2"
+version = "0.5.0"
 description = "graphql-codegen powered by pydantic"
 authors = ["jhnnsrs <jhnnsrs@gmail.com>"]
 license = "MIT"

--- a/turms/plugins/enums.py
+++ b/turms/plugins/enums.py
@@ -21,7 +21,7 @@ class EnumsPluginConfig(PluginConfig):
     type = "turms.plugins.enums.EnumsPlugin"
     skip_underscore: bool = False
     skip_double_underscore: bool = True
-    skip_unreferenced: bool = False
+    skip_unreferenced: bool = True
     prepend: str = ""
     append: str = ""
 
@@ -35,7 +35,6 @@ def generate_enums(
     plugin_config: EnumsPluginConfig,
     registry: ClassRegistry,
 ):
-
     tree = []
 
     enum_types = {
@@ -44,7 +43,7 @@ def generate_enums(
         if isinstance(value, GraphQLEnumType)
     }
 
-    if plugin_config.skip_unreferenced:
+    if plugin_config.skip_unreferenced and config.documents:
         ref_registry = create_reference_registry_from_documents(
             client_schema, parse_documents(client_schema, config.documents)
         )
@@ -52,7 +51,6 @@ def generate_enums(
         ref_registry = None
 
     for key, type in enum_types.items():
-
         if ref_registry and key not in ref_registry.enums:
             continue
 
@@ -71,7 +69,6 @@ def generate_enums(
         )
 
         for value_key, value in type.values.items():
-
             if isinstance(value.value, str):
                 servalue = value.value
             else:
@@ -129,7 +126,6 @@ class EnumsPlugin(Plugin):
         config: GeneratorConfig,
         registry: ClassRegistry,
     ) -> List[ast.AST]:
-
         registry.register_import("enum.Enum")
 
         return generate_enums(client_schema, config, self.config, registry)

--- a/turms/plugins/funcs.py
+++ b/turms/plugins/funcs.py
@@ -514,6 +514,12 @@ def genereate_async_call(
             )
         )
     else:
+        correct_attr = (
+            o.selection_set.selections[0].alias.value
+            if o.selection_set.selections[0].alias
+            else o.selection_set.selections[0].name.value
+        )
+
         return ast.Return(
             value=ast.Attribute(
                 value=ast.Await(
@@ -534,9 +540,7 @@ def genereate_async_call(
                         ],
                     )
                 ),
-                attr=registry.generate_node_name(
-                    o.selection_set.selections[0].name.value
-                ),
+                attr=registry.generate_node_name(correct_attr),
                 ctx=ast.Load(),
             )
         )
@@ -570,6 +574,12 @@ def genereate_sync_call(
             )
         )
     else:
+        correct_attr = (
+            o.selection_set.selections[0].alias.value
+            if o.selection_set.selections[0].alias
+            else o.selection_set.selections[0].name.value
+        )
+
         return ast.Return(
             value=ast.Attribute(
                 value=ast.Call(
@@ -588,9 +598,7 @@ def genereate_sync_call(
                         generate_variable_dict(o, plugin_config, registry),
                     ],
                 ),
-                attr=registry.generate_node_name(
-                    o.selection_set.selections[0].name.value
-                ),
+                attr=registry.generate_node_name(correct_attr),
                 ctx=ast.Load(),
             )
         )
@@ -629,6 +637,12 @@ def genereate_async_iterator(
             orelse=[],
         )
     else:
+        correct_attr = (
+            o.selection_set.selections[0].alias.value
+            if o.selection_set.selections[0].alias
+            else o.selection_set.selections[0].name.value
+        )
+
         return ast.AsyncFor(
             target=ast.Name(id="event", ctx=ast.Store()),
             iter=ast.Call(
@@ -651,9 +665,7 @@ def genereate_async_iterator(
                         value=ast.Attribute(
                             value=ast.Name(id="event", ctx=ast.Load()),
                             ctx=ast.Load(),
-                            attr=registry.generate_node_name(
-                                o.selection_set.selections[0].name.value
-                            ),
+                            attr=registry.generate_node_name(correct_attr),
                         )
                     )
                 ),
@@ -695,6 +707,12 @@ def genereate_sync_iterator(
             orelse=[],
         )
     else:
+        correct_attr = (
+            o.selection_set.selections[0].alias.value
+            if o.selection_set.selections[0].alias
+            else o.selection_set.selections[0].name.value
+        )
+
         return ast.For(
             target=ast.Name(id="event", ctx=ast.Store()),
             iter=ast.Call(
@@ -717,9 +735,7 @@ def genereate_sync_iterator(
                         value=ast.Attribute(
                             value=ast.Name(id="event", ctx=ast.Load()),
                             ctx=ast.Load(),
-                            attr=registry.generate_node_name(
-                                o.selection_set.selections[0].name.value
-                            ),
+                            attr=registry.generate_node_name(correct_attr),
                         )
                     )
                 ),

--- a/turms/plugins/inputs.py
+++ b/turms/plugins/inputs.py
@@ -29,7 +29,7 @@ class InputsPluginConfig(PluginConfig):
     type = "turms.plugins.inputs.InputsPlugin"
     inputtype_bases: List[str] = ["pydantic.BaseModel"]
     skip_underscore: bool = True
-    skip_unreferenced: bool = False
+    skip_unreferenced: bool = True
 
     class Config:
         env_prefix = "TURMS_PLUGINS_INPUTS_"
@@ -106,7 +106,6 @@ def generate_input_annotation(
                 )
 
         if is_optional:
-
             registry.register_import("typing.Optional")
             return ast.Subscript(
                 value=ast.Name("Optional", ctx=ast.Load()),
@@ -138,7 +137,6 @@ def generate_inputs(
     plugin_config: InputsPluginConfig,
     registry: ClassRegistry,
 ):
-
     tree = []
 
     inputobjects_type = {
@@ -147,7 +145,7 @@ def generate_inputs(
         if isinstance(value, GraphQLInputObjectType)
     }
 
-    if plugin_config.skip_unreferenced:
+    if plugin_config.skip_unreferenced and config.documents:
         ref_registry = create_reference_registry_from_documents(
             client_schema, parse_documents(client_schema, config.documents)
         )
@@ -158,7 +156,6 @@ def generate_inputs(
         registry.register_import(base)
 
     for key, type in inputobjects_type.items():
-
         if ref_registry and key not in ref_registry.inputs:
             continue
 
@@ -174,7 +171,6 @@ def generate_inputs(
         )
 
         for value_key, value in type.fields.items():
-
             field_name = registry.generate_node_name(value_key)
 
             if field_name != value_key:
@@ -263,7 +259,6 @@ class InputsPlugin(Plugin):
         config: GeneratorConfig,
         registry: ClassRegistry,
     ) -> List[ast.AST]:
-
         for base in self.config.inputtype_bases:
             registry.register_import(base)
 

--- a/turms/plugins/strawberry.py
+++ b/turms/plugins/strawberry.py
@@ -49,7 +49,6 @@ def default_generate_directives(
     plugin_config: "StrawberryPluginConfig",
     registry: ClassRegistry,
 ):
-
     tree = []
 
     directives = client_schema.directives
@@ -66,7 +65,6 @@ def default_generate_directives(
     registry.register_import("strawberry.schema_directive.Location")
 
     for directive in generatable_directives:
-
         if plugin_config.skip_underscore and directive.name.startswith("_"):
             continue
 
@@ -158,7 +156,6 @@ def default_generate_enums(
     }
 
     for key, type in enum_types.items():
-
         directive_keywords = generate_directive_keywords(type.ast_node, plugin_config)
         if directive_keywords:
             decorator = ast.Call(
@@ -184,7 +181,6 @@ def default_generate_enums(
         )
 
         for value_key, value in type.values.items():
-
             if isinstance(value.value, str):
                 servalue = value.value
             else:
@@ -362,10 +358,12 @@ def generate_object_field_annotation(
         )
 
     if isinstance(graphql_type, GraphQLList):
-
         registry.register_import("typing.List")
+
         def list_builder(x):
-            return ast.Subscript(value=ast.Name("List", ctx=ast.Load()), slice=x, ctx=ast.Load())
+            return ast.Subscript(
+                value=ast.Name("List", ctx=ast.Load()), slice=x, ctx=ast.Load()
+            )
 
         if is_optional:
             registry.register_import("typing.Optional")
@@ -396,7 +394,9 @@ def generate_object_field_annotation(
             )
         )
 
-    raise NotImplementedError(f"Unknown object type {repr(graphql_type)}") # pragma: no cover
+    raise NotImplementedError(
+        f"Unknown object type {repr(graphql_type)}"
+    )  # pragma: no cover
 
 
 def recurse_argument_annotation(
@@ -501,10 +501,12 @@ def recurse_argument_annotation(
         )
 
     if isinstance(graphql_type, GraphQLList):
-
         registry.register_import("typing.List")
+
         def list_builder(x):
-            return ast.Subscript(value=ast.Name("List", ctx=ast.Load()), slice=x, ctx=ast.Load())
+            return ast.Subscript(
+                value=ast.Name("List", ctx=ast.Load()), slice=x, ctx=ast.Load()
+            )
 
         if is_optional:
             registry.register_import("typing.Optional")
@@ -582,7 +584,6 @@ def generate_inputs(
     plugin_config: StrawberryPluginConfig,
     registry: ClassRegistry,
 ):
-
     tree = []
 
     inputobjects_type = {
@@ -592,7 +593,6 @@ def generate_inputs(
     }
 
     for key, type in inputobjects_type.items():
-
         if plugin_config.skip_underscore and key.startswith("_"):  # pragma: no cover
             continue
 
@@ -688,7 +688,6 @@ def generate_types(
     plugin_config: StrawberryPluginConfig,
     registry: ClassRegistry,
 ):
-
     tree = []
 
     objects = {
@@ -717,7 +716,6 @@ def generate_types(
     ] = {}  # A list of interfaces with its respective base
 
     for key, object_type in sorted_objects.items():
-
         additional_bases = get_additional_bases_for_type(
             object_type.name, config, registry
         )
@@ -794,7 +792,6 @@ def generate_types(
             additional_args = []
             kwdefaults = []
             if value.args:
-
                 sorted_args = {
                     key: value
                     for key, value in sorted(
@@ -805,7 +802,6 @@ def generate_types(
                 }
 
                 for argkey, arg in sorted_args.items():
-
                     additional_args.append(
                         ast.arg(
                             arg=registry.generate_parameter_name(argkey),
@@ -842,7 +838,6 @@ def generate_types(
             keywords += generate_directive_keywords(value.ast_node, plugin_config)
 
             if not additional_args and key not in ["Mutation", "Subscription", "Query"]:
-
                 if not keywords:
                     assign_value = None
                 else:
@@ -930,7 +925,6 @@ def generate_scalars(
     plugin_config: StrawberryPluginConfig,
     registry: ClassRegistry,
 ):
-
     objects = {
         key: value
         for key, value in client_schema.type_map.items()
@@ -944,7 +938,6 @@ def generate_scalars(
         registry.register_import("typing.NewType")
 
     for key, scalar in objects.items():
-
         keywords = []
         keywords += generate_directive_keywords(scalar.ast_node, plugin_config)
         if scalar.description:
@@ -1030,7 +1023,6 @@ class StrawberryPlugin(Plugin):
         config: GeneratorConfig,
         registry: ClassRegistry,
     ) -> List[ast.AST]:
-
         registry.register_import("strawberry")
 
         directives = (

--- a/turms/referencer.py
+++ b/turms/referencer.py
@@ -182,7 +182,6 @@ def recurse_type_annotation(
             # We need to get all input objects that this graphql input object type references
 
             for key, node in graphql_type.fields.items():
-                print("key", key, node)
                 recurse_type_annotation(node, node.type, schema, registry)
 
     else:

--- a/turms/utils.py
+++ b/turms/utils.py
@@ -49,8 +49,10 @@ class FragmentNotFoundError(GenerationError):
 class NoDocumentsFoundError(GenerationError):
     pass
 
+
 class InvalidDocuments(GenerationError):
     pass
+
 
 class NoScalarEquivalentDefined(GenerationError):
     pass
@@ -222,6 +224,13 @@ def generate_config_class(
                 )
 
     if len(config_fields) > 0:
+        config_fields.insert(
+            0,
+            ast.Expr(
+                value=ast.Str(s="A config class"),
+            ),
+        )
+    if len(config_fields) > 0:
         return [
             ast.ClassDef(
                 name="Config",
@@ -259,7 +268,9 @@ def parse_documents(client_schema: GraphQLSchema, scan_glob) -> DocumentNode:
 
     errors = validate(client_schema, nodes)
     if len(errors) > 0:
-        raise InvalidDocuments("Invalid Documents \n" + "\n".join(str(e) for e in errors))
+        raise InvalidDocuments(
+            "Invalid Documents \n" + "\n".join(str(e) for e in errors)
+        )
 
     return nodes
 
@@ -294,7 +305,6 @@ def replace_iteratively(
 def get_additional_bases_for_type(
     typename, config: GeneratorConfig, registry: ClassRegistry
 ):
-
     if typename in config.additional_bases:
         for base in config.additional_bases[typename]:
             registry.register_import(base)
@@ -307,7 +317,6 @@ def get_additional_bases_for_type(
 
 
 def get_interface_bases(config: GeneratorConfig, registry: ClassRegistry):
-
     if config.interface_bases:
         for base in config.interface_bases:
             registry.register_import(base)
@@ -343,7 +352,6 @@ def recurse_type_annotation(
     optional=True,
     overwrite_final: Optional[str] = None,
 ):
-
     if isinstance(type, NonNullTypeNode):
         return recurse_type_annotation(
             type.type, registry, optional=False, overwrite_final=overwrite_final
@@ -450,7 +458,6 @@ def recurse_outputtype_annotation(
         return registry.reference_enum(type.name, "", allow_forward=False)
 
     if isinstance(type, GraphQLScalarType):
-
         if optional:
             registry.register_import("typing.Optional")
             return ast.Subscript(
@@ -462,7 +469,6 @@ def recurse_outputtype_annotation(
             return registry.reference_scalar(type.name)
 
     if isinstance(type, GraphQLObjectType) or isinstance(type, GraphQLInterfaceType):
-
         assert overwrite_final, "Needs to be set"
         if optional:
             registry.register_import("typing.Optional")
@@ -517,7 +523,6 @@ def recurse_outputtype_label(
         return registry.reference_enum(type.name, "", allow_forward=False).id
 
     if isinstance(type, GraphQLScalarType):
-
         if optional:
             return "Optional[" + registry.reference_scalar(type.name).id + "]"
 
@@ -525,7 +530,6 @@ def recurse_outputtype_label(
             return registry.reference_scalar(type.name).id
 
     if isinstance(type, GraphQLObjectType) or isinstance(type, GraphQLInterfaceType):
-
         assert overwrite_final, "Needs to be set"
         if optional:
             return "Optional[" + overwrite_final + "]"
@@ -542,7 +546,6 @@ def recurse_type_label(
     optional=True,
     overwrite_final: Optional[str] = None,
 ):
-
     if isinstance(type, NonNullTypeNode):
         return recurse_type_label(
             type.type, registry, optional=False, overwrite_final=overwrite_final


### PR DESCRIPTION
Fixes: Enums and Inputs plugin when unreferenced
Breaking: Sets enums and inputs plugins: skip_unreferenced as True by default,