### PR TITLE
Set default values for optional field in input types

### DIFF
--- a/tests/test_optional_input_fields.py
+++ b/tests/test_optional_input_fields.py
@@ -1,0 +1,47 @@
+import ast
+from graphql import parse, build_ast_schema
+from turms.config import GeneratorConfig
+from turms.run import generate_ast
+from turms.stylers.snake_case import SnakeCaseStyler
+from turms.plugins.inputs import InputsPlugin
+from turms.plugins.objects import ObjectsPlugin
+from .utils import unit_test_with
+
+inputs = '''
+input X {
+    mandatory: String!
+    otherMandatory: String!
+    optional: String
+    otherOptional: String
+}
+'''
+
+
+expected = '''class X(BaseModel):
+    mandatory: str
+    other_mandatory: str = Field(alias='otherMandatory')
+    optional: Optional[str] = None
+    other_optional: Optional[str] = Field(alias='otherOptional', default=None)'''
+
+
+def test_generates_schema(snapshot):
+    config = GeneratorConfig()
+
+    schema = build_ast_schema(parse(inputs))
+
+    generated_ast = generate_ast(
+        config,
+        schema,
+        stylers=[SnakeCaseStyler()],
+        plugins=[
+            InputsPlugin(),
+            ObjectsPlugin(),
+        ],
+    )
+
+    unit_test_with(generated_ast, '')
+
+    without_imports = [node for node in generated_ast if not isinstance(node, ast.ImportFrom)]
+    md = ast.Module(body=without_imports, type_ignores=[])
+    generated = ast.unparse(ast.fix_missing_locations(md))
+    assert generated == expected

--- a/turms/plugins/inputs.py
+++ b/turms/plugins/inputs.py
@@ -175,6 +175,16 @@ def generate_inputs(
 
             if field_name != value_key:
                 registry.register_import("pydantic.Field")
+                keywords = [
+                    ast.keyword(
+                        arg="alias", value=ast.Constant(value=value_key)
+                    )
+                ]
+                if not isinstance(value.type, GraphQLNonNull):
+                    keywords.append(
+                        ast.keyword(arg="default", value=ast.Constant(None))
+                    )
+
                 assign = ast.AnnAssign(
                     target=ast.Name(field_name, ctx=ast.Store()),
                     annotation=generate_input_annotation(
@@ -188,14 +198,11 @@ def generate_inputs(
                     value=ast.Call(
                         func=ast.Name(id="Field", ctx=ast.Load()),
                         args=[],
-                        keywords=[
-                            ast.keyword(
-                                arg="alias", value=ast.Constant(value=value_key)
-                            )
-                        ],
+                        keywords=keywords,
                     ),
                     simple=1,
                 )
+
             else:
                 assign = ast.AnnAssign(
                     target=ast.Name(value_key, ctx=ast.Store()),
@@ -208,6 +215,7 @@ def generate_inputs(
                         is_optional=True,
                     ),
                     simple=1,
+                    value=ast.Constant(None) if not isinstance(value.type, GraphQLNonNull) else None,
                 )
 
             potential_comment = (


### PR DESCRIPTION
For given input

```
input X {
  field: str
  otherField: str
}
```

It changes:
* `field: Optional[str]` to `field: Optional[str] = None` if there is no pydantic field
* `other_field: Optional[str] = Field(alias="otherField")` to `other_field: Optional[str] = Field(alias="otherField", default=None)` otherwise

Resolves #74