### PR TITLE
Loosen version constraint on dependency 'rich'.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-rich = "^11.0.0"
+rich = ">=11,<14"
 graphql-core = "^3.2.0"
 pydantic = ">2"
 PyYAML = ">=5.3.0"


### PR DESCRIPTION
It works for me with `rich-13.9.2` (and I have another dependency that requires `>=12`, creating a conflict with the current constraint).