### PR TITLE
fix: add sort to the fragments to have deterministic output

### DIFF
--- a/turms/utils.py
+++ b/turms/utils.py
@@ -562,6 +562,8 @@ def replace_iteratively(
     z = set(fragment_searcher.findall(pattern))  # only set is important
 
     new_fragments = [new_f for new_f in z if new_f not in taken and new_f != ""]
+    new_fragments.sort()
+
     if not new_fragments:
         return pattern
     else:


### PR DESCRIPTION
Turms is a fantastic package to add to your CI pipeline. But to make it work in a CI workflow the outputs have to be fully deterministic. The order of the pydantic objects was set to be deterministic by this [PR](https://github.com/jhnnsrs/turms/pull/91/files) a few months ago. But when a query has various fragments defined we hit the same issue.

This one liner fixes the issue.  

