### PR TITLE
Correctly expand nested fragments on interface fragment

### DIFF
--- a/tests/documents/interface_fragment_collapse/fragments/layer.graphql
+++ b/tests/documents/interface_fragment_collapse/fragments/layer.graphql
@@ -5,3 +5,27 @@ fragment Layer on Layer {
     lens
   }
 }
+
+# Deliberately declared before its concrete dependencies to verify that nested
+# spreads participate in fragment dependency ordering.
+fragment LayerFull on Layer {
+  ... on ImageLayer {
+    ...ImageLayerFull
+  }
+  ... on MeshLayer {
+    ...MeshLayerFull
+  }
+}
+
+fragment ImageLayerFull on ImageLayer {
+  id
+  scene
+  lens
+  status
+}
+
+fragment MeshLayerFull on MeshLayer {
+  id
+  scene
+  mesh
+}

--- a/tests/documents/interface_fragment_collapse/fragments/layer.graphql
+++ b/tests/documents/interface_fragment_collapse/fragments/layer.graphql
@@ -29,3 +29,14 @@ fragment MeshLayerFull on MeshLayer {
   scene
   mesh
 }
+
+fragment LayerMeta on Layer {
+  id
+}
+
+fragment ImageLayerMeta on ImageLayer {
+  ...LayerMeta
+  imageDetails {
+    id
+  }
+}

--- a/tests/documents/interface_fragment_collapse/operations/layer.graphql
+++ b/tests/documents/interface_fragment_collapse/operations/layer.graphql
@@ -23,3 +23,22 @@ query GetLayer($id: ID!) {
     ...Layer
   }
 }
+
+# Exercises the generated interface fragment implementations.
+query GetLayerFull($id: ID!) {
+  layer(id: $id) {
+    ...LayerFull
+  }
+}
+
+# Exercises recurse.py directly without a named interface fragment.
+query GetInlineLayerFull($id: ID!) {
+  layer(id: $id) {
+    ... on ImageLayer {
+      ...ImageLayerFull
+    }
+    ... on MeshLayer {
+      ...MeshLayerFull
+    }
+  }
+}

--- a/tests/documents/interface_fragment_collapse/operations/layer.graphql
+++ b/tests/documents/interface_fragment_collapse/operations/layer.graphql
@@ -42,3 +42,22 @@ query GetInlineLayerFull($id: ID!) {
     }
   }
 }
+
+query GetOverlappingLayerMeta($id: ID!) {
+  layer(id: $id) {
+    ...LayerMeta
+    ... on ImageLayer {
+      ...ImageLayerMeta
+    }
+  }
+}
+
+# The same selections in reverse order must generate the same valid bases.
+query GetReversedOverlappingLayerMeta($id: ID!) {
+  layer(id: $id) {
+    ... on ImageLayer {
+      ...ImageLayerMeta
+    }
+    ...LayerMeta
+  }
+}

--- a/tests/schemas/interface_fragment_collapse.graphql
+++ b/tests/schemas/interface_fragment_collapse.graphql
@@ -24,6 +24,11 @@ type ImageLayer implements Layer {
   scene: String!
   lens: String!
   status: String!
+  imageDetails: ImageDetails!
+}
+
+type ImageDetails {
+  id: ID!
 }
 
 type MeshLayer implements Layer {

--- a/tests/test_interface_fragment_collapse.py
+++ b/tests/test_interface_fragment_collapse.py
@@ -80,6 +80,13 @@ def _func_return_annotation(tree, func_name):
     raise AssertionError(f"function {func_name} not found in generated tree")
 
 
+def _class_bases(tree, class_name):
+    for node in tree:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {base.id for base in node.bases if isinstance(base, ast.Name)}
+    raise AssertionError(f"class {class_name} not found in generated tree")
+
+
 def test_interface_fragment_collapse_imports(interface_fragment_collapse_schema):
     """The generated module must be valid, importable Python (no dangling
     reference to the interface fragment name)."""
@@ -129,3 +136,61 @@ def test_interface_field_still_produces_union(interface_fragment_collapse_schema
     annotation = _class_field_annotation(generated_ast, "GetLayer", "layer")
     assert "Union" in annotation
     assert "discriminator" in annotation
+
+
+def test_interface_fragment_inline_spreads_inherit_concrete_fragments(
+    interface_fragment_collapse_schema,
+):
+    generated_ast = _generate(interface_fragment_collapse_schema, with_funcs=False)
+
+    assert "ImageLayerFull" in _class_bases(generated_ast, "LayerFullImageLayer")
+    assert "MeshLayerFull" in _class_bases(generated_ast, "LayerFullMeshLayer")
+
+    unit_test_with(
+        generated_ast,
+        """
+        result = GetLayerFull(
+            layer={
+                "__typename": "ImageLayer",
+                "id": "layer-1",
+                "scene": "scene-1",
+                "lens": "wide",
+                "status": "ready",
+            }
+        )
+        assert result.layer.id == "layer-1"
+        assert result.layer.lens == "wide"
+        assert result.layer.status == "ready"
+        """,
+    )
+
+
+def test_operation_interface_inline_spreads_inherit_concrete_fragments(
+    interface_fragment_collapse_schema,
+):
+    generated_ast = _generate(interface_fragment_collapse_schema, with_funcs=False)
+
+    assert "ImageLayerFull" in _class_bases(
+        generated_ast, "GetInlineLayerFullLayerBaseImageLayer"
+    )
+    assert "MeshLayerFull" in _class_bases(
+        generated_ast, "GetInlineLayerFullLayerBaseMeshLayer"
+    )
+
+    unit_test_with(
+        generated_ast,
+        """
+        result = GetInlineLayerFull(
+            layer={
+                "__typename": "ImageLayer",
+                "id": "layer-1",
+                "scene": "scene-1",
+                "lens": "wide",
+                "status": "ready",
+            }
+        )
+        assert result.layer.id == "layer-1"
+        assert result.layer.lens == "wide"
+        assert result.layer.status == "ready"
+        """,
+    )

--- a/tests/test_interface_fragment_collapse.py
+++ b/tests/test_interface_fragment_collapse.py
@@ -194,3 +194,38 @@ def test_operation_interface_inline_spreads_inherit_concrete_fragments(
         assert result.layer.status == "ready"
         """,
     )
+
+
+def test_overlapping_interface_fragment_bases_are_pruned(
+    interface_fragment_collapse_schema,
+):
+    generated_ast = _generate(interface_fragment_collapse_schema, with_funcs=False)
+
+    class_names = [
+        "GetOverlappingLayerMetaLayerBaseImageLayer",
+        "GetReversedOverlappingLayerMetaLayerBaseImageLayer",
+    ]
+    bases = [_class_bases(generated_ast, class_name) for class_name in class_names]
+
+    for class_bases in bases:
+        assert "ImageLayerMeta" in class_bases
+        assert "LayerMetaImageLayer" not in class_bases
+
+    unit_test_with(
+        generated_ast,
+        """
+        for result_type in (
+            GetOverlappingLayerMeta,
+            GetReversedOverlappingLayerMeta,
+        ):
+            result = result_type(
+                layer={
+                    "__typename": "ImageLayer",
+                    "id": "layer-1",
+                    "imageDetails": {"id": "details-1"},
+                }
+            )
+            assert result.layer.id == "layer-1"
+            assert result.layer.image_details.id == "details-1"
+        """,
+    )

--- a/turms/plugins/fragments.py
+++ b/turms/plugins/fragments.py
@@ -71,6 +71,13 @@ def find_fragment_dependencies_recursive(
                     selection.selection_set, fragment_definitions, visited
                 )
             )
+        # Inline fragments can contain fragment spreads too.
+        elif isinstance(selection, InlineFragmentNode):
+            dependencies.update(
+                find_fragment_dependencies_recursive(
+                    selection.selection_set, fragment_definitions, visited
+                )
+            )
 
     return dependencies
 
@@ -262,6 +269,24 @@ def generate_fragment(
                 inline_fields = []
 
                 for field in sub_node.selection_set.selections:
+                    if isinstance(field, FragmentSpreadNode):
+                        try:
+                            implementation_map = (
+                                registry.get_interface_fragment_implementations(
+                                    field.name.value
+                                )
+                            )
+                            implementation = implementation_map.get(on_type_name)
+                            if implementation:
+                                implementing_class_base_classes.setdefault(
+                                    on_type_name, []
+                                ).append(implementation)
+                        except KeyError:
+                            implementing_class_base_classes.setdefault(
+                                on_type_name, []
+                            ).append(registry.inherit_fragment(field.name.value))
+                        continue
+
                     if isinstance(field, FieldNode):
                         if field.name.value == "__typename":
                             continue

--- a/turms/plugins/fragments.py
+++ b/turms/plugins/fragments.py
@@ -228,7 +228,7 @@ def generate_fragment(
         # i.e eg subtype of the interface
         implementing_class_base_classes: Dict[str, List[str]] = {}
 
-        # This is a map of inlien fragments field on their respective types
+        # This is a map of inline fragments field on their respective types
         inline_fragment_fields: Dict[str, List[ast.AnnAssign | ast.Expr]] = {}
 
         for sub_node in sub_nodes:
@@ -352,7 +352,7 @@ def generate_fragment(
         tree.append(mother_class)
         tree.append(catch_class)
 
-        implementaionMap: Dict[str, str] = {}
+        implementation_map: Dict[str, str] = {}
 
         for i in implementing_types.objects:
             class_name = f"{base_fragment_name}{i.name}"
@@ -365,22 +365,26 @@ def generate_fragment(
                 else ast.Expr(value=ast.Constant(value="No documentation"))
             )
 
+            fragment_base_names = registry.prune_redundant_generated_bases(
+                implementing_class_base_classes.get(i.name, [])
+            )
             ast_base_nodes = [
                 ast.Name(id=x, ctx=ast.Load())
-                for x in implementing_class_base_classes.get(i.name, [])
+                for x in fragment_base_names
             ]
-            implementaionMap[i.name] = class_name
+            implementation_map[i.name] = class_name
 
             inline_fields = inline_fragment_fields.get(i.name, [])
+            implementing_bases = merge_bases_sequences(
+                ast_base_nodes,
+                [ast.Name(id=mother_class_name, ctx=ast.Load())],
+                additional_bases,
+                get_interface_bases(config, registry),
+            )
 
             implementing_class = ast.ClassDef(
                 class_name,
-                bases=merge_bases_sequences(
-                    ast_base_nodes,
-                    [ast.Name(id=mother_class_name, ctx=ast.Load())],
-                    additional_bases,
-                    get_interface_bases(config, registry),
-                ),  # Todo: fill with base
+                bases=implementing_bases,  # Todo: fill with base
                 decorator_list=[],
                 keywords=[],
                 type_params=[],
@@ -394,9 +398,17 @@ def generate_fragment(
             )
 
             tree.append(implementing_class)
+            registry.register_generated_class_bases(
+                class_name,
+                [
+                    base.id
+                    for base in implementing_bases
+                    if isinstance(base, ast.Name)
+                ],
+            )
 
         registry.register_interface_fragment_implementations(
-            f.name.value, implementaionMap
+            f.name.value, implementation_map
         )
 
         return tree
@@ -493,13 +505,14 @@ def generate_fragment(
         else:
             meta_body = []
 
+        fragment_bases = merge_bases_sequences(
+            additional_bases,
+            get_fragment_bases("OBJECT", config, plugin_config, registry),
+        )
         tree.append(
             ast.ClassDef(
                 name,
-                bases=merge_bases_sequences(
-                    additional_bases,
-                    get_fragment_bases("OBJECT", config, plugin_config, registry),
-                ),
+                bases=fragment_bases,
                 decorator_list=[],
                 keywords=[],
                 type_params=[],
@@ -509,6 +522,10 @@ def generate_fragment(
                     meta_body,
                 ),
             )
+        )
+        registry.register_generated_class_bases(
+            name,
+            [base.id for base in fragment_bases if isinstance(base, ast.Name)],
         )
         return tree
 

--- a/turms/recurse.py
+++ b/turms/recurse.py
@@ -341,7 +341,7 @@ def recurse_annotation(
         )
         subtree.append(mother_class)
 
-        implementaionMap = {}
+        implementation_map = {}
         union_class_names = []
 
         for i in implementing_types.objects:
@@ -355,11 +355,14 @@ def recurse_annotation(
                 else ast.Expr(value=ast.Constant(value="No documentation"))
             )
 
+            fragment_base_names = registry.prune_redundant_generated_bases(
+                implementing_class_base_classes.get(i.name, [])
+            )
             ast_base_nodes = [
                 ast.Name(id=x, ctx=ast.Load())
-                for x in implementing_class_base_classes.get(i.name, [])
+                for x in fragment_base_names
             ]
-            implementaionMap[i.name] = class_name
+            implementation_map[i.name] = class_name
 
             inline_fields: List[ast.AnnAssign | ast.Expr] = inline_fragment_fields.get(
                 i.name, cast(List[ast.AnnAssign | ast.Expr], [])

--- a/turms/recurse.py
+++ b/turms/recurse.py
@@ -277,6 +277,24 @@ def recurse_annotation(
                 inline_fields = []
 
                 for field in sub_node.selection_set.selections:
+                    if isinstance(field, FragmentSpreadNode):
+                        try:
+                            implementation_map = (
+                                registry.get_interface_fragment_implementations(
+                                    field.name.value
+                                )
+                            )
+                            implementation = implementation_map.get(on_type_name)
+                            if implementation:
+                                implementing_class_base_classes.setdefault(
+                                    on_type_name, []
+                                ).append(implementation)
+                        except KeyError:
+                            implementing_class_base_classes.setdefault(
+                                on_type_name, []
+                            ).append(registry.inherit_fragment(field.name.value))
+                        continue
+
                     if not isinstance(field, FieldNode):
                         continue
 

--- a/turms/registry.py
+++ b/turms/registry.py
@@ -1,6 +1,6 @@
 import ast
 from keyword import iskeyword
-from typing import Callable, Dict, List, Optional, Set, Type
+from typing import Callable, Dict, List, Optional, Sequence, Set, Type
 
 from graphql import DocumentNode, GraphQLNamedType
 
@@ -255,6 +255,10 @@ class ClassRegistry(object):
         self.interfacefragments_impl_map: Dict[str, Dict[str, str]] = {}
         self.unionfragment_members_map: Dict[str, Dict[str, str]] = {}
 
+        self.generated_class_bases: Dict[
+              str, Set[str]
+          ] = {} # This is used to store the generated class bases for each class to avoid MRO issues
+
         self.operation_single_operation_map: Dict[
             str, ast.AST
         ] = {}  # This is used to store the operation name and the root operation class name if single
@@ -446,6 +450,39 @@ class ClassRegistry(object):
         self, fragmentname: str, implementationMap: Dict[str, str]
     ):
         self.interfacefragments_impl_map[fragmentname] = implementationMap
+
+    def register_generated_class_bases(
+        self, classname: str, bases: Sequence[str]
+    ) -> None:
+        """Record generated inheritance for transitive base pruning."""
+        self.generated_class_bases[classname] = set(bases)
+
+    def prune_redundant_generated_bases(self, bases: Sequence[str]) -> List[str]:
+        """Remove bases inherited by another selected generated base.
+
+        Sorting makes the resulting inheritance independent of GraphQL selection
+        order. Only known generated inheritance participates, so configured or
+        imported bases retain their existing handling elsewhere.
+        """
+        candidates = set(bases)
+
+        def inherits(classname: str, ancestor: str, visited: Set[str]) -> bool:
+            if classname in visited:
+                return False
+            visited.add(classname)
+            direct_bases = self.generated_class_bases.get(classname, set())
+            return ancestor in direct_bases or any(
+                inherits(base, ancestor, visited) for base in direct_bases
+            )
+
+        return sorted(
+            candidate
+            for candidate in candidates
+            if not any(
+                candidate != other and inherits(other, candidate, set())
+                for other in candidates
+            )
+        )
 
     def get_interface_fragment_implementations(self, fragmentname: str):
         return self.interfacefragments_impl_map[fragmentname]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "turms"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "graphql-core" },


### PR DESCRIPTION
Without this patch only the `__typename` is added, this correctly recurse and add the nested fragment as base class.

```graphql
fragment LayerFull on Layer {
  ... on ImageLayer {
    ...ImageLayerFull
  }
  ... on MeshLayer {
    ...MeshLayerFull
  }
}

fragment ImageLayerFull on ImageLayer {
  id
}

fragment MeshLayerFull on MeshLayer {
  id
}
```

I had to add a new concept to track the base classes otherwise it would result in MRO problems like:
```python
class TaskMetaReplayTask(TaskMetaBase, Model):
    typename: Literal["ReplayTask"] = Field(alias="__typename", default="ReplayTask")

class ReplayTaskMeta(TaskMetaReplayTask, Model):
    typename: Literal["ReplayTask"] = Field(alias="__typename", default="ReplayTask")
    replayEntry: ReplayTaskMetaReplayentry

    class Meta:
        document = "fragment TaskMeta on Task {\n  __typename\n  id\n  createdAt\n}\n\nfragment ReplayTaskMeta on ReplayTask {\n  ...TaskMeta\n  replayEntry {\n    id\n    __typename\n  }\n  __typename\n}"
        name = "ReplayTaskMeta"
        type = "ReplayTask"

class TasksTasksBaseReplayTask(ReplayTaskMeta, TasksTasksBase, Model):
    typename: Literal["ReplayTask"] = Field(alias="__typename", default="ReplayTask")
```

The class `TasksTasksBaseReplayTask` cannot have as base `TaskMetaReplayTask` since it is also the base of `ReplayTaskMeta`.

This happens in cases where the fragment is re-used twice, once in the parent and once in the nested fragment like:

```graphql
fragment LayerMeta on Layer {
  id
}

fragment ImageLayerMeta on ImageLayer {
  ...LayerMeta
  imageDetails {
    id
  }
}

query GetOverlappingLayerMeta($id: ID!) {
  layer(id: $id) {
    ...LayerMeta
    ... on ImageLayer {
      ...ImageLayerMeta
    }
  }
}
```

Again I am not too familiar with the lib so this is very heavily AI assisted, but it works and it has a regression tests.
There might be a better way to track the base classes.