### PR TITLE
fix(strawberry): give omittable input fields a Python default

### DIFF
--- a/tests/plugins/strawberry/snapshots/input_field_defaults.py
+++ b/tests/plugins/strawberry/snapshots/input_field_defaults.py
@@ -1,0 +1,17 @@
+import strawberry
+
+
+@strawberry.input
+class FieldDefaultsInput:
+    nullableNoDefault: str | None = strawberry.field(default=None)
+    nullableWithDefault: str | None = strawberry.field(default='fallback')
+    requiredWithDefault: str = strawberry.field(default='required-fallback')
+    requiredNoDefault: str
+    nullableListWithDefault: list[str] | None = strawberry.field(default_factory=lambda: ['a', 'b'])
+
+@strawberry.type
+class Query:
+
+    @strawberry.field()
+    def hi(self) -> str | None:
+        return None

--- a/tests/plugins/strawberry/snapshots/input_field_defaults.py
+++ b/tests/plugins/strawberry/snapshots/input_field_defaults.py
@@ -7,7 +7,6 @@ class FieldDefaultsInput:
     nullableWithDefault: str | None = strawberry.field(default='fallback')
     requiredWithDefault: str = strawberry.field(default='required-fallback')
     requiredNoDefault: str
-    nullableListWithDefault: list[str] | None = strawberry.field(default_factory=lambda: ['a', 'b'])
 
 @strawberry.type
 class Query:

--- a/tests/plugins/strawberry/snapshots/nested_inputs.py
+++ b/tests/plugins/strawberry/snapshots/nested_inputs.py
@@ -8,7 +8,7 @@ class RemoveItemFromPlaylistTrackInput:
 @strawberry.input
 class RemoveItemFromPlaylistInput:
     playlistId: str
-    snapshotId: str | None
+    snapshotId: str | None = strawberry.field(default=None)
     tracks: list[RemoveItemFromPlaylistTrackInput]
 
 @strawberry.type

--- a/tests/plugins/strawberry/test_input_field_defaults.py
+++ b/tests/plugins/strawberry/test_input_field_defaults.py
@@ -13,7 +13,9 @@ from graphql import parse
 from turms.config import GeneratorConfig
 from turms.plugins.strawberry import StrawberryPlugin
 from turms.processors.isort import IsortProcessor
-from turms.run import build_ast_schema, generate_code
+from turms.run import build_ast_schema, generate_ast, generate_code
+
+from ...utils import unit_test_with
 
 SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
 
@@ -27,18 +29,27 @@ input FieldDefaultsInput {
     nullableWithDefault: String = "fallback"
     requiredWithDefault: String! = "required-fallback"
     requiredNoDefault: String!
-    nullableListWithDefault: [String!] = ["a", "b"]
+}
+"""
+
+list_default_schema = """
+type Query {
+    hi: String
+}
+
+input ListDefaultInput {
+    tags: [String!] = ["a", "b"]
 }
 """
 
 
-def _generate_schema(schema: str):
-    config = GeneratorConfig(
-        scalar_definitions={"_Any": "typing.Any"}, skip_forwards=True
-    )
+def _config():
+    return GeneratorConfig(scalar_definitions={"_Any": "typing.Any"}, skip_forwards=True)
 
+
+def _generate_schema(schema: str):
     return generate_code(
-        config,
+        _config(),
         schema=build_ast_schema(parse(schema)),
         plugins=[StrawberryPlugin()],
         processors=[IsortProcessor()],
@@ -48,3 +59,42 @@ def _generate_schema(schema: str):
 def test_generates_schema(snapshot):
     snapshot.snapshot_dir = SNAPSHOTS_DIR
     snapshot.assert_match(_generate_schema(schema), "input_field_defaults.py")
+
+
+def test_omitting_every_optional_field_constructs_successfully():
+    """The exact crash this fix addresses: a caller supplying only the
+    required field must not hit a missing-keyword-argument TypeError for
+    fields it left out."""
+    generated_ast = generate_ast(
+        _config(),
+        build_ast_schema(parse(schema)),
+        plugins=[StrawberryPlugin()],
+    )
+
+    unit_test_with(
+        generated_ast,
+        "i = FieldDefaultsInput(requiredNoDefault='x')\n"
+        "assert i.nullableNoDefault is None\n"
+        "assert i.nullableWithDefault == 'fallback'\n"
+        "assert i.requiredWithDefault == 'required-fallback'\n"
+        "assert i.requiredNoDefault == 'x'\n",
+    )
+
+
+def test_omitted_list_default_uses_a_fresh_list_each_time():
+    """A mutable default must go through default_factory, not default= -
+    otherwise every instance would share (and could mutate) the same list."""
+    generated_ast = generate_ast(
+        _config(),
+        build_ast_schema(parse(list_default_schema)),
+        plugins=[StrawberryPlugin()],
+    )
+
+    unit_test_with(
+        generated_ast,
+        "a = ListDefaultInput()\n"
+        "b = ListDefaultInput()\n"
+        "assert a.tags == ['a', 'b']\n"
+        "a.tags.append('c')\n"
+        "assert b.tags == ['a', 'b']\n",
+    )

--- a/tests/plugins/strawberry/test_input_field_defaults.py
+++ b/tests/plugins/strawberry/test_input_field_defaults.py
@@ -1,0 +1,50 @@
+"""An input field a caller may omit - because it is nullable, or because it
+carries a schema default - must get a Python default in the generated
+dataclass. Without one, strawberry has no value to fall back on when a
+client omits the field, and construction fails with a
+"missing required keyword-only argument" TypeError even though the GraphQL
+schema says the field is optional to provide.
+"""
+
+import pathlib
+
+from graphql import parse
+
+from turms.config import GeneratorConfig
+from turms.plugins.strawberry import StrawberryPlugin
+from turms.processors.isort import IsortProcessor
+from turms.run import build_ast_schema, generate_code
+
+SNAPSHOTS_DIR = pathlib.Path(__file__).parent / "snapshots"
+
+schema = """
+type Query {
+    hi: String
+}
+
+input FieldDefaultsInput {
+    nullableNoDefault: String
+    nullableWithDefault: String = "fallback"
+    requiredWithDefault: String! = "required-fallback"
+    requiredNoDefault: String!
+    nullableListWithDefault: [String!] = ["a", "b"]
+}
+"""
+
+
+def _generate_schema(schema: str):
+    config = GeneratorConfig(
+        scalar_definitions={"_Any": "typing.Any"}, skip_forwards=True
+    )
+
+    return generate_code(
+        config,
+        schema=build_ast_schema(parse(schema)),
+        plugins=[StrawberryPlugin()],
+        processors=[IsortProcessor()],
+    )
+
+
+def test_generates_schema(snapshot):
+    snapshot.snapshot_dir = SNAPSHOTS_DIR
+    snapshot.assert_match(_generate_schema(schema), "input_field_defaults.py")

--- a/turms/plugins/strawberry.py
+++ b/turms/plugins/strawberry.py
@@ -780,6 +780,33 @@ def generate_inputs(
                     )
                 )
 
+            # A caller may omit this field when it is nullable or carries a
+            # schema default; either way the generated dataclass needs a
+            # Python default so the field isn't a required constructor
+            # argument the caller is forced to pass.
+            has_default = value.default_value is not Undefined
+            omittable = has_default or not isinstance(value.type, GraphQLNonNull)
+
+            if omittable:
+                default = (
+                    convert_default_value_to_ast(value.default_value)
+                    if has_default
+                    else ast.Constant(value=None)
+                )
+
+                needs_factory = isinstance(default, (ast.List, ast.Dict))
+
+                keywords.append(
+                    ast.keyword(
+                        arg="default_factory" if needs_factory else "default",
+                        value=(
+                            ast.Lambda(args=[], body=default)
+                            if needs_factory
+                            else default
+                        ),
+                    )
+                )
+
             if keywords:
                 assign_value = ast.Call(
                     func=ast.Name(

--- a/uv.lock
+++ b/uv.lock
@@ -455,7 +455,7 @@ resolution-markers = [
     "python_full_version >= '3.14'",
 ]
 dependencies = [
-    { name = "pyyaml-ft" },
+    { name = "pyyaml-ft", marker = "python_full_version >= '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/55/ca4552d7fe79a91b2a7b4fa39991e8a45a17c8bfbcaf264597d95903c777/libcst-1.8.5.tar.gz", hash = "sha256:e72e1816eed63f530668e93a4c22ff1cf8b91ddce0ec53e597d3f6c53e103ec7", size = 884582, upload-time = "2025-09-26T05:29:44.101Z" }
 wheels = [
@@ -527,7 +527,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml", marker = "python_full_version < '3.13'" },
     { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/c0/098e5c91ff1537f00c85a6438b6cb1863d17144680cc91f47c87f104a200/libcst-1.9.0.tar.gz", hash = "sha256:087b58a9afe076bb08e2d726478e1f16cb928d67ffa9092817e033c335de522a", size = 914739, upload-time = "2026-07-29T21:28:43.153Z" }
@@ -1245,7 +1245,7 @@ wheels = [
 
 [[package]]
 name = "turms"
-version = "1.2.1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "graphql-core" },


### PR DESCRIPTION
`StrawberryPlugin.generate_inputs()` only ever passed description/ deprecation_reason to strawberry.field(...), never reading a field's GraphQL default_value. An input field a caller is allowed to omit  was still generated as a required keyword-only argument on the dataclass. Any client omitting the field crashed construction with a `missing required keyword-only argument` TypeError instead of falling back to null/the schema default.

`InputsPlugin` already handles this correct so this mirrors that logic for the server-side StrawberryPlugin, reusing the existing default/default_factory convention from default_generate_directives for mutable (list/dict) defaults.