### PR TITLE
Support adding info argument to generated strawberry resolvers

### DIFF
--- a/tests/test_schema_strawberry.py
+++ b/tests/test_schema_strawberry.py
@@ -5,7 +5,7 @@ from turms.run import generate_ast
 from turms.plugins.strawberry import StrawberryPlugin, StrawberryPluginConfig
 from turms.stylers.default import DefaultStyler
 from turms.run import generate_ast
-from .utils import unit_test_with
+from .utils import parse_to_code, unit_test_with
 
 
 @pytest.mark.network
@@ -129,6 +129,35 @@ def test_custom_scalar_generation(scalar_schema):
         ],
         skip_forwards=True,
     )
+
+    unit_test_with(generated_ast, "")
+
+
+def test_resolver_info_argument(arkitekt_schema):
+    config = GeneratorConfig(
+        scalar_definitions={
+            "QString": "str",
+            "Any": "str",
+            "UUID": "pydantic.UUID4",
+            "Callback": "str",
+        }
+    )
+
+    generated_ast = generate_ast(
+        config,
+        arkitekt_schema,
+        stylers=[DefaultStyler()],
+        plugins=[
+            StrawberryPlugin(
+                config=StrawberryPluginConfig(resolver_info_argument=True)
+            ),
+        ],
+        skip_forwards=True,
+    )
+
+    source = parse_to_code(generated_ast)
+    assert "from strawberry.types import Info" in source
+    assert "info: Info" in source
 
     unit_test_with(generated_ast, "")
 

--- a/turms/plugins/strawberry.py
+++ b/turms/plugins/strawberry.py
@@ -381,6 +381,7 @@ class StrawberryPluginConfig(PluginConfig):
         return rename_deprecated_keys(values, {"inputtype_bases": "input_bases"})
     skip_underscore: bool = False
     skip_double_underscore: bool = True
+    resolver_info_argument: bool = False
 
     # Functional configuration:
     generate_directives_func: StrawberryGenerateFunc = default_generate_directives
@@ -1061,11 +1062,18 @@ def generate_types(
                     args=[],
                 )
 
+                info_args = []
+                if plugin_config.resolver_info_argument:
+                    registry.register_import("strawberry.types.Info")
+                    info_args = [
+                        ast.arg(arg="info", annotation=ast.Name(id="Info", ctx=ast.Load()))
+                    ]
+
                 assign = function_def(
                     name=registry.generate_node_name(value_key),
                     returns=returns,
                     args=ast.arguments(
-                        args=[ast.arg(arg="self")] + additional_args,
+                        args=[ast.arg(arg="self")] + info_args + additional_args,
                         posonlyargs=[],
                         kwonlyargs=[],
                         kw_defaults=[],

--- a/website/docs/plugins/strawberry.md
+++ b/website/docs/plugins/strawberry.md
@@ -39,6 +39,7 @@ project:
             input_bases: [] # additional input type bases
             skip_underscore: False # skip generated underscored types
             skip_double_underscore: True # skip generatind double underscored types
+            resolver_info_argument: False # add an `info: Info` argument to generated resolvers
 ```
 
 


### PR DESCRIPTION
Adds an opt-in `resolver_info_argument` config flag to the strawberry plugin. 

When enabled, generated resolver methods (Query/Mutation/Subscription fields and any field with arguments) receive an
`info: Info` parameter after `self`, with the `strawberry.types.Info` import added automatically.

Defaults to False to keep existing generated signatures unchanged.