### PR TITLE
Preserve manual-added decorator keywords when merging

### DIFF
--- a/tests/merge_pairs/decorator_new.py
+++ b/tests/merge_pairs/decorator_new.py
@@ -1,0 +1,12 @@
+class Mutation:
+    @strawberry.mutation()
+    def createProject(self, info):
+        pass
+
+    @strawberry.mutation(description="New description")
+    def createPdcVersion(self, info):
+        pass
+
+    @strawberry.field()
+    def unrelatedField(self, info):
+        pass

--- a/tests/merge_pairs/decorator_old.py
+++ b/tests/merge_pairs/decorator_old.py
@@ -1,0 +1,15 @@
+class Mutation:
+    @strawberry.mutation(extensions=[PermissionExtension([IsAdmin()])])
+    def createProject(self, info):
+        return do_create(info)
+
+    @strawberry.mutation(
+        description="Old description",
+        extensions=[PermissionExtension([CanMutateProject(get_project_id=_direct_project_id)])],
+    )
+    def createPdcVersion(self, info):
+        return do_create_pdc_version(info)
+
+    @strawberry.field()
+    def unrelatedField(self, info):
+        return None

--- a/tests/merge_pairs/decorator_updated.py
+++ b/tests/merge_pairs/decorator_updated.py
@@ -1,0 +1,13 @@
+class Mutation:
+    @strawberry.mutation(extensions=[PermissionExtension([IsAdmin()])])
+    def createProject(self, info):
+        return do_create(info)
+
+    @strawberry.mutation(description="New description", extensions=[PermissionExtension([CanMutateProject(get_project_id=_direct_project_id)])],
+    )
+    def createPdcVersion(self, info):
+        return do_create_pdc_version(info)
+
+    @strawberry.field()
+    def unrelatedField(self, info):
+        return None

--- a/tests/test_merge_processor.py
+++ b/tests/test_merge_processor.py
@@ -19,3 +19,24 @@ def test_merge_code():
     assert (
         result == new_code
     ), "The merge_code function did not merge the code correctly"
+
+
+def test_merge_code_preserves_hand_added_decorator_keywords():
+    """Decorator keyword arguments with no schema representation (e.g. Strawberry's
+    `permission_classes`/`extensions`) have no way to be regenerated, so a merge must
+    preserve them from the existing file - only keywords present in the freshly
+    generated decorator (e.g. `description`) should be allowed to update."""
+
+    with open(build_relative_glob("/merge_pairs/decorator_old.py"), "r") as f:
+        old_code = f.read()
+
+    with open(build_relative_glob("/merge_pairs/decorator_new.py"), "r") as f:
+        new_code = f.read()
+
+    result = merge_code(old_code, new_code, MergeProcessorConfig())
+
+    with open(build_relative_glob("/merge_pairs/decorator_updated.py"), "r") as f:
+        expected_code = f.read()
+    assert (
+        result == expected_code
+    ), "The merge_code function did not preserve hand-added decorator keywords"

--- a/turms/processors/merge.py
+++ b/turms/processors/merge.py
@@ -3,6 +3,7 @@ from turms.processors.base import Processor, ProcessorConfig
 import libcst as cst
 from collections import OrderedDict
 from turms.config import GeneratorConfig
+from typing import Optional, Sequence
 import os
 
 # load beasts.py as a ast.Module
@@ -16,12 +17,68 @@ def retrieve_symbol_name(simple_statement: cst.SimpleStatementLine):
         return None
 
 
+def _decorator_call(decorator: cst.Decorator) -> Optional[cst.Call]:
+    return decorator.decorator if isinstance(decorator.decorator, cst.Call) else None
+
+
+def _code_for(node: cst.CSTNode) -> str:
+    return cst.Module(body=[]).code_for_node(node)
+
+
+def merge_decorator(generated: cst.Decorator, existing: cst.Decorator) -> cst.Decorator:
+    """Merges a single decorator.
+
+    Keeps every keyword argument from the freshly generated decorator, 
+    but preserves any additional keyword arguments that only exist 
+    on the hand-edited (existing) decorator.
+    """
+
+    generated_call = _decorator_call(generated)
+    existing_call = _decorator_call(existing)
+
+    if generated_call is None or existing_call is None:
+        return generated
+
+    if _code_for(generated_call.func) != _code_for(existing_call.func):
+        # Different callable entirely (e.g. strawberry.field -> strawberry.mutation) -
+        # not safe to merge keywords across different call targets.
+        return generated
+
+    generated_keywords = {
+        arg.keyword.value for arg in generated_call.args if arg.keyword is not None
+    }
+    preserved_args = [
+        arg
+        for arg in existing_call.args
+        if arg.keyword is not None and arg.keyword.value not in generated_keywords
+    ]
+
+    if not preserved_args:
+        return generated
+
+    merged_call = generated_call.with_changes(args=[*generated_call.args, *preserved_args])
+    return generated.with_changes(decorator=merged_call)
+
+
+def merge_decorators(
+    generated: Sequence[cst.Decorator], existing: Sequence[cst.Decorator]
+) -> Sequence[cst.Decorator]:
+    return [
+        merge_decorator(gen_dec, existing[index]) if index < len(existing) else gen_dec
+        for index, gen_dec in enumerate(generated)
+    ]
+
+
 def merge_functions(generated: cst.FunctionDef, existing: cst.FunctionDef):
     # merge the two functions
 
-    # we want to merge the body of the new function into the existing one
+    # we want to merge the body of the new function into the existing one, and preserve
+    # any hand-added decorator keyword arguments that have no schema representation
 
-    new_def = generated.with_changes(body=existing.body)
+    new_def = generated.with_changes(
+        body=existing.body,
+        decorators=merge_decorators(generated.decorators, existing.decorators),
+    )
     return new_def
 
 


### PR DESCRIPTION
Merge processor takes full decorator from generated code, discarding manual added decorators. For ex. this silently drops Strawberry specific decorator args like `permission_classes` and `extensions` which we would like to support.

I've updated it such that `merge_functions` now merges the decorator too - 

Keywords present in the freshly generated decorator (e.g. description, kept in sync with schema doc-comments) still get the regenerated value, but any keyword that exists only on the existing decorator is preserved as-is. Decorators whose callable target differs (e.g. strawberry.field → strawberry.mutation) are left untouched, since merging keywords across different calls isn't safe